### PR TITLE
Add editable results

### DIFF
--- a/src/LinqStudio.Abstractions/Models/QueryExecutionResult.cs
+++ b/src/LinqStudio.Abstractions/Models/QueryExecutionResult.cs
@@ -7,9 +7,9 @@ namespace LinqStudio.Abstractions.Models;
 public record QueryExecutionResult
 {
 	/// <summary>
-	/// The data rows returned by the query. Each row is a dictionary of column name to value.
+	/// The materialized result objects. Entity queries use these for typed editing.
 	/// </summary>
-	public required IReadOnlyList<IReadOnlyDictionary<string, object?>> Rows { get; init; }
+	public required IReadOnlyList<object> Items { get; init; }
 
 	/// <summary>
 	/// The column names in the result set, in the order they appear.
@@ -52,7 +52,7 @@ public record QueryExecutionResult
 	/// </summary>
 	public static QueryExecutionResult Empty(TimeSpan elapsed) => new()
 	{
-		Rows = [],
+		Items = [],
 		ColumnNames = [],
 		Elapsed = elapsed
 	};
@@ -62,7 +62,7 @@ public record QueryExecutionResult
 	/// </summary>
 	public static QueryExecutionResult FromError(string message, bool isCompileError, TimeSpan elapsed) => new()
 	{
-		Rows = [],
+		Items = [],
 		ColumnNames = [],
 		Elapsed = elapsed,
 		ErrorMessage = message,

--- a/src/LinqStudio.Blazor/Components/DynamicPropertyColumn.razor.cs
+++ b/src/LinqStudio.Blazor/Components/DynamicPropertyColumn.razor.cs
@@ -1,0 +1,46 @@
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace LinqStudio.Blazor.Components;
+
+/// <summary>
+/// A runtime-typed wrapper around MudBlazor's standard PropertyColumn.
+/// </summary>
+public class DynamicPropertyColumn<TProperty> : PropertyColumn<object, TProperty>
+{
+	[Parameter, EditorRequired]
+	public string ColumnName { get; set; } = string.Empty;
+
+	[Parameter, EditorRequired]
+	public PropertyInfo PropertyInfo { get; set; } = null!;
+
+	[Parameter, EditorRequired]
+	public EventCallback<QueryResultGrid.CellChanged> OnCellChanged { get; set; }
+
+	[Parameter]
+	public bool IsEditable { get; set; }
+
+	protected override void OnParametersSet()
+	{
+		Title = ColumnName;
+		Editable = IsEditable;
+
+		var item = Expression.Parameter(typeof(object), "x");
+		Property = Expression.Lambda<Func<object, TProperty>>(
+			Expression.Property(
+				Expression.Convert(item, PropertyInfo.DeclaringType!),
+				PropertyInfo),
+			item);
+
+		base.OnParametersSet();
+	}
+
+	protected override void SetProperty(object? item, object? value)
+	{
+		base.SetProperty(item, value);
+		if (item is not null)
+			_ = OnCellChanged.InvokeAsync(new QueryResultGrid.CellChanged(item, ColumnName, value?.ToString()));
+	}
+}

--- a/src/LinqStudio.Blazor/Components/Pages/Editor/QueryEditorPanel.razor
+++ b/src/LinqStudio.Blazor/Components/Pages/Editor/QueryEditorPanel.razor
@@ -127,7 +127,12 @@
 		<MudTabs KeepPanelsAlive="true" Class="results-tabs" data-testid="results-tabs">
 			<MudTabPanel Text="Results" Icon="@Icons.Material.Filled.TableChart" data-testid="results-tab-panel">
 				<QueryResultGrid Result="@_result"
-								 IsExecuting="@_isExecuting" />
+								 IsExecuting="@_isExecuting"
+								 IsEditable="@(_result is not null && _queryExecutionService?.IsEntityResult(_result) == true)"
+								 EditableColumns="@_editableColumns"
+								 EditableRow="@_selectedEntity"
+								 OnCellChanged="OnEntityCellChanged"
+								 OnRowSelected="OnEntityRowSelected" />
 			</MudTabPanel>
 
 			<MudTabPanel Text="C#" Icon="@Icons.Material.Filled.Code" data-testid="csharp-tab-panel">

--- a/src/LinqStudio.Blazor/Components/Pages/Editor/QueryEditorPanel.razor.cs
+++ b/src/LinqStudio.Blazor/Components/Pages/Editor/QueryEditorPanel.razor.cs
@@ -87,8 +87,8 @@ public partial class QueryEditorPanel : ComponentBase, IDisposable, IAsyncDispos
 	/// <summary>Gets or sets the MudBlazor dialog service for unsaved-changes confirmation.</summary>
 	[Inject] private IDialogService DialogService { get; set; } = null!;
 
-	/// <summary>Gets or sets the service that compiles and executes LINQ queries.</summary>
-	[Inject] private IQueryExecutionService QueryExecutionService { get; set; } = null!;
+	/// <summary>Gets or sets the factory used to create the per-panel query execution service.</summary>
+	[Inject] private IQueryExecutionServiceFactory QueryExecutionServiceFactory { get; set; } = null!;
 
 	/// <summary>Gets or sets the JS runtime for Monaco relayout and splitter interop calls.</summary>
 	[Inject] private IJSRuntime JSRuntime { get; set; } = null!;
@@ -114,6 +114,7 @@ public partial class QueryEditorPanel : ComponentBase, IDisposable, IAsyncDispos
 	private bool _isExecuting;
 	private CancellationTokenSource? _executionCts;
 	private int _selectedTimeout = 30;
+	private IQueryExecutionService? _queryExecutionService;
 
 	private bool _delay = true;
 	private bool _splitterInitialized;
@@ -194,6 +195,7 @@ public partial class QueryEditorPanel : ComponentBase, IDisposable, IAsyncDispos
 	protected override void OnInitialized()
 	{
 		_selectedTimeout = QueryExecutionSettings.CurrentValue.TimeoutSeconds;
+		_queryExecutionService = QueryExecutionServiceFactory.Create();
 	}
 
 	/// <summary>
@@ -663,7 +665,7 @@ public partial class QueryEditorPanel : ComponentBase, IDisposable, IAsyncDispos
 
 		try
 		{
-			var result = await QueryExecutionService.ExecuteQueryAsync(queryText, Workspace.CurrentProject, _executionCts.Token);
+			var result = await _queryExecutionService!.ExecuteQueryAsync(queryText, Workspace.CurrentProject, _executionCts.Token);
 			_result = result;
 
 			// Update viewer editors if they are already mounted (e.g. user ran a second query
@@ -733,6 +735,11 @@ public partial class QueryEditorPanel : ComponentBase, IDisposable, IAsyncDispos
 	/// </remarks>
 	public async ValueTask DisposeAsync()
 	{
+		if(_disposed)
+		{
+			return;
+		}
+
 		// Must be first — guards all in-flight awaited continuations (OnTabActivatedAsync, OnAfterRenderAsync).
 		_disposed = true;
 
@@ -748,7 +755,18 @@ public partial class QueryEditorPanel : ComponentBase, IDisposable, IAsyncDispos
 			}
 		}
 
-		Dispose();
+		_providerDisposable?.Dispose();
+		_hoverProviderDisposable?.Dispose();
+		_debounceTokenSource?.Cancel();
+		_debounceTokenSource?.Dispose();
+		_executionCts?.Cancel();
+		_executionCts?.Dispose();
+		_localCompiler?.Dispose();
+		if (_queryExecutionService is not null)
+		{
+			await _queryExecutionService.DisposeAsync();
+		}
+		_queryExecutionService = null;
 		GC.SuppressFinalize(this);
 	}
 
@@ -762,6 +780,11 @@ public partial class QueryEditorPanel : ComponentBase, IDisposable, IAsyncDispos
 	/// </remarks>
 	public void Dispose()
 	{
+		if(_disposed)
+		{
+			return;
+		}
+
 		// Ensure the disposed flag is set even when called directly (not via DisposeAsync).
 		_disposed = true;
 
@@ -775,5 +798,7 @@ public partial class QueryEditorPanel : ComponentBase, IDisposable, IAsyncDispos
 		_executionCts?.Dispose();
 
 		_localCompiler?.Dispose();
+		_queryExecutionService?.Dispose();
+		_queryExecutionService = null;
 	}
 }

--- a/src/LinqStudio.Blazor/Components/Pages/Editor/QueryEditorPanel.razor.cs
+++ b/src/LinqStudio.Blazor/Components/Pages/Editor/QueryEditorPanel.razor.cs
@@ -1,12 +1,10 @@
 using BlazorMonaco;
 using BlazorMonaco.Editor;
 using BlazorMonaco.Languages;
-using LinqStudio.Abstractions;
 using LinqStudio.Abstractions.Models;
-using LinqStudio.Blazor.Components.Dialogs;
-using LinqStudio.Blazor.Constants;
 using LinqStudio.Blazor.Extensions;
 using LinqStudio.Blazor.Services;
+using LinqStudio.Core.Resources;
 using LinqStudio.Core.Services;
 using LinqStudio.Core.Settings;
 using Microsoft.AspNetCore.Components;
@@ -115,6 +113,8 @@ public partial class QueryEditorPanel : ComponentBase, IDisposable, IAsyncDispos
 	private CancellationTokenSource? _executionCts;
 	private int _selectedTimeout = 30;
 	private IQueryExecutionService? _queryExecutionService;
+	private object? _selectedEntity;
+	private IReadOnlySet<string> _editableColumns = new HashSet<string>(StringComparer.Ordinal);
 
 	private bool _delay = true;
 	private bool _splitterInitialized;
@@ -651,6 +651,8 @@ public partial class QueryEditorPanel : ComponentBase, IDisposable, IAsyncDispos
 			return;
 		}
 
+		await SaveEditedRowAsync();
+
 		_executionCts?.Cancel();
 		_executionCts?.Dispose();
 
@@ -667,6 +669,8 @@ public partial class QueryEditorPanel : ComponentBase, IDisposable, IAsyncDispos
 		{
 			var result = await _queryExecutionService!.ExecuteQueryAsync(queryText, Workspace.CurrentProject, _executionCts.Token);
 			_result = result;
+			_selectedEntity = null;
+			_editableColumns = _queryExecutionService.GetEditableColumns(result);
 
 			// Update viewer editors if they are already mounted (e.g. user ran a second query
 			// without the editors being unmounted). Since _result = null clears them at the start
@@ -684,9 +688,10 @@ public partial class QueryEditorPanel : ComponentBase, IDisposable, IAsyncDispos
 
 			if (result.Success)
 			{
-				Snackbar.Add($"Query executed successfully. {result.Rows.Count} row(s) returned.", Severity.Success);
+				Snackbar.Add($"Query executed successfully. {result.Items.Count} row(s) returned.", Severity.Success);
 			}
 		}
+
 		catch (OperationCanceledException)
 		{
 			_result = QueryExecutionResult.FromError("Query execution was cancelled.", false, TimeSpan.Zero);
@@ -703,6 +708,45 @@ public partial class QueryEditorPanel : ComponentBase, IDisposable, IAsyncDispos
 			_executionCts?.Dispose();
 			_executionCts = null;
 			StateHasChanged();
+		}
+	}
+
+	private async Task OnEntityRowSelected(object entity)
+	{
+		await SaveEditedRowAsync();
+		_selectedEntity = entity;
+	}
+
+	private async Task OnEntityCellChanged(QueryResultGrid.CellChanged change)
+	{
+		try
+		{
+			if (_queryExecutionService is not null)
+				_queryExecutionService.UpdateEntityProperty(change.Row, change.ColumnName, change.Value);
+
+			_selectedEntity ??= change.Row;
+		}
+		catch (Exception ex)
+		{
+			Logger.LogError(ex, "Failed to update edited query result cell.");
+			await ErrorHandlingService.HandleErrorAsync(ex, SharedResource.QueryEditor_Error_UpdateEditedCell);
+		}
+	}
+
+	private async Task SaveEditedRowAsync()
+	{
+		if (_selectedEntity is null || _queryExecutionService is null || _result is null
+			|| !_queryExecutionService.IsEntityResult(_result))
+			return;
+
+		try
+		{
+			await _queryExecutionService.SaveChangesAsync();
+		}
+		catch (Exception ex)
+		{
+			Logger.LogError(ex, "Failed to save edited query result row.");
+			await ErrorHandlingService.HandleErrorAsync(ex, SharedResource.QueryEditor_Error_SaveEditedRow);
 		}
 	}
 
@@ -735,7 +779,7 @@ public partial class QueryEditorPanel : ComponentBase, IDisposable, IAsyncDispos
 	/// </remarks>
 	public async ValueTask DisposeAsync()
 	{
-		if(_disposed)
+		if (_disposed)
 		{
 			return;
 		}
@@ -780,7 +824,7 @@ public partial class QueryEditorPanel : ComponentBase, IDisposable, IAsyncDispos
 	/// </remarks>
 	public void Dispose()
 	{
-		if(_disposed)
+		if (_disposed)
 		{
 			return;
 		}

--- a/src/LinqStudio.Blazor/Components/Pages/Editor/copilot.md
+++ b/src/LinqStudio.Blazor/Components/Pages/Editor/copilot.md
@@ -20,6 +20,7 @@ The editor info bar contains a "Refresh Schema" button that re-initializes the `
 - Per-tab execution state: `_result`, `_isExecuting`, `_executionCts`, `_selectedTimeout`
 - All Monaco logic: `_lastQueryText`, `_debounceTokenSource`, `_delay`, `_splitterInitialized`
 - Compiler fallback: creates a `_localCompiler` in `OnEditorInitialized` if the shared `Compiler` param is null
+- Query execution: creates an isolated `IQueryExecutionService` during initialization and disposes it with the panel
 
 ### Key method: `OnTabActivatedAsync()`
 Called by `Editor.OnActivePanelIndexChanged` when a tab becomes active:

--- a/src/LinqStudio.Blazor/Components/Pages/Editor/copilot.md
+++ b/src/LinqStudio.Blazor/Components/Pages/Editor/copilot.md
@@ -21,6 +21,7 @@ The editor info bar contains a "Refresh Schema" button that re-initializes the `
 - All Monaco logic: `_lastQueryText`, `_debounceTokenSource`, `_delay`, `_splitterInitialized`
 - Compiler fallback: creates a `_localCompiler` in `OnEditorInitialized` if the shared `Compiler` param is null
 - Query execution: creates an isolated `IQueryExecutionService` during initialization and disposes it with the panel
+- Entity results expose scalar inputs in `QueryResultGrid`; edits update tracked entities and are saved when the selected result row changes (and before re-execution)
 
 ### Key method: `OnTabActivatedAsync()`
 Called by `Editor.OnActivePanelIndexChanged` when a tab becomes active:

--- a/src/LinqStudio.Blazor/Components/QueryResultGrid.razor
+++ b/src/LinqStudio.Blazor/Components/QueryResultGrid.razor
@@ -2,100 +2,89 @@
 
 @if (IsExecuting)
 {
-	<div class="d-flex align-center pa-4">
-		<MudProgressCircular Indeterminate="true" Size="Size.Small" Class="mr-3" />
-		<MudText Typo="Typo.body1">Executing query...</MudText>
-	</div>
+    <div class="d-flex align-center pa-4">
+        <MudProgressCircular Indeterminate="true" Size="Size.Small" Class="mr-3" />
+        <MudText Typo="Typo.body1">Executing query...</MudText>
+    </div>
 }
 else if (Result is not null)
 {
-	@if (!Result.Success)
-	{
-		<MudAlert Severity="Severity.Error" Variant="Variant.Filled" Class="my-2">
-			<MudText Typo="Typo.body1">
-				@if (Result.IsCompileError)
-				{
-					<strong>Compilation error:</strong>
-					@(" ")
-				}
-				@Result.ErrorMessage
-			</MudText>
-			<MudText Typo="Typo.caption" Class="mt-2">
-				Elapsed: @FormatElapsedTime(Result.Elapsed)
-			</MudText>
-		</MudAlert>
-	}
-	else if (Result.Rows.Count == 0)
-	{
-		<MudAlert Severity="Severity.Info" Variant="Variant.Filled" Class="my-2">
-			<MudText Typo="Typo.body1">Query returned no results.</MudText>
-			<MudText Typo="Typo.caption" Class="mt-2">
-				Elapsed: @FormatElapsedTime(Result.Elapsed)
-			</MudText>
-		</MudAlert>
-	}
-	else
-	{
-		<div class="mt-2 query-result-grid-container" @onkeydown="OnKeyDown" tabindex="0">
-			<MudDataGrid T="IReadOnlyDictionary<string, object>"
-						 Items="@Result.Rows"
-						 Dense="true"
-						 Hover="true"
-						 Striped="true"
-						 FixedHeader="true"
-						 Virtualize="true"
-						 Height="100%"
-						 ColumnResizeMode="ResizeMode.Container"
-						 DragDropColumnReordering="true"
-						 MultiSelection="false"
-						 SelectOnRowClick="false"
-						 RowClick="@OnMudRowClick"
-						 RowClassFunc="@GetRowClass"
-						 Elevation="0"
-						 @ref="_dataGrid"
-						 data-testid="query-result-grid">
-				<Columns>
-					@foreach (var colName in Result.ColumnNames)
-					{
-						<TemplateColumn T="IReadOnlyDictionary<string, object>"
-										Title="@colName"
-										Sortable="true"
-										SortBy="@(row => row.GetValueOrDefault(colName)?.ToString() ?? string.Empty)">
-							<HeaderTemplate>
-								<div data-testid="@($"column-header-{colName}")">@colName</div>
-							</HeaderTemplate>
-							<CellTemplate>
-								@{
-									var cellValue = context.Item.GetValueOrDefault(colName);
-									var cellStr = cellValue is null ? "NULL" : cellValue.ToString();
-									var rowIndex = GetRowIndex(context.Item);
-								}
-								<div style="width:100%; height:100%; padding:4px"
-									 data-testid="@($"cell-{rowIndex}-{colName}")">
-									@cellStr
-								</div>
-							</CellTemplate>
-						</TemplateColumn>
-					}
-				</Columns>
-			</MudDataGrid>
-			<div class="d-flex justify-space-between align-center pa-2">
-				@if (_selectedRows.Count > 0)
-				{
-					<div data-testid="selection-count">
-						<MudText Typo="Typo.caption" Class="mud-text-secondary">
-							@_selectedRows.Count @(_selectedRows.Count == 1 ? "row" : "rows") selected
-						</MudText>
-					</div>
-				}
-				else
-				{
-					<div></div>
-				}
-				<MudText Typo="Typo.caption" Class="mud-text-secondary">
-					@Result.Rows.Count @(Result.Rows.Count == 1 ? "row" : "rows") · @FormatElapsedTime(Result.Elapsed)
-				</MudText>
-			</div>
-		</div>
-	}
+    @if (!Result.Success)
+    {
+        <MudAlert Severity="Severity.Error" Variant="Variant.Filled" Class="my-2">
+            <MudText Typo="Typo.body1">
+                @if (Result.IsCompileError)
+                {
+                    <strong>Compilation error:</strong>
+                    @(" ")
+                }
+                @Result.ErrorMessage
+            </MudText>
+            <MudText Typo="Typo.caption" Class="mt-2">
+                Elapsed: @FormatElapsedTime(Result.Elapsed)
+            </MudText>
+        </MudAlert>
+    }
+    else if (Result.Items.Count == 0)
+    {
+        <MudAlert Severity="Severity.Info" Variant="Variant.Filled" Class="my-2">
+            <MudText Typo="Typo.body1">Query returned no results.</MudText>
+            <MudText Typo="Typo.caption" Class="mt-2">
+                Elapsed: @FormatElapsedTime(Result.Elapsed)
+            </MudText>
+        </MudAlert>
+    }
+    else
+    {
+        <div class="mt-2 query-result-grid-container" @onkeydown="OnKeyDown" tabindex="0">
+            <MudDataGrid T="object"
+                         Items="@GridItems"
+                         Dense="true"
+                         Hover="true"
+                         Striped="true"
+                         FixedHeader="true"
+                         Virtualize="true"
+                         Height="100%"
+                         ReadOnly="@(!IsEditable || !HasEditableRuntimeItems)"
+                         EditMode="@(IsEditable ? DataGridEditMode.Cell : null)"
+                         ColumnResizeMode="ResizeMode.Container"
+                         DragDropColumnReordering="true"
+                         MultiSelection="false"
+                         SelectOnRowClick="false"
+                         RowClick="@OnMudRowClick"
+                         RowClassFunc="@GetRowClass"
+                         Elevation="0"
+                         @ref="_dataGrid"
+                         data-testid="query-result-grid">
+                <Columns>
+                    @foreach (var colName in Result.ColumnNames)
+                    {
+                        var property = GetRuntimeProperty(colName);
+                        if (property != null)
+                        {
+                            <DynamicComponent Type="@typeof(DynamicPropertyColumn<>).MakeGenericType(property!.PropertyType)"
+                                              Parameters="@GetRuntimeColumnParameters(colName, property!)" />
+                        }
+                    }
+                </Columns>
+            </MudDataGrid>
+            <div class="d-flex justify-space-between align-center pa-2">
+                @if (_selectedRows.Count > 0)
+                {
+                    <div data-testid="selection-count">
+                        <MudText Typo="Typo.caption" Class="mud-text-secondary">
+                            @_selectedRows.Count @(_selectedRows.Count == 1 ? "row" : "rows") selected
+                        </MudText>
+                    </div>
+                }
+                else
+                {
+                    <div></div>
+                }
+                <MudText Typo="Typo.caption" Class="mud-text-secondary">
+                    @Result.Items.Count @(Result.Items.Count == 1 ? "row" : "rows") · @FormatElapsedTime(Result.Elapsed)
+                </MudText>
+            </div>
+        </div>
+    }
 }

--- a/src/LinqStudio.Blazor/Components/QueryResultGrid.razor.cs
+++ b/src/LinqStudio.Blazor/Components/QueryResultGrid.razor.cs
@@ -10,16 +10,33 @@ namespace LinqStudio.Blazor.Components;
 
 public partial class QueryResultGrid : ComponentBase
 {
+	public sealed record CellChanged(object Row, string ColumnName, string? Value);
+
 	[Parameter]
 	public QueryExecutionResult? Result { get; set; }
 
 	[Parameter]
 	public bool IsExecuting { get; set; }
 
+	[Parameter]
+	public bool IsEditable { get; set; }
+
+	[Parameter]
+	public IReadOnlySet<string> EditableColumns { get; set; } = new HashSet<string>(StringComparer.Ordinal);
+
+	[Parameter]
+	public object? EditableRow { get; set; }
+
+	[Parameter]
+	public EventCallback<CellChanged> OnCellChanged { get; set; }
+
+	[Parameter]
+	public EventCallback<object> OnRowSelected { get; set; }
+
 	[Inject]
 	private IClipboardService ClipboardService { get; set; } = null!;
 
-	private MudDataGrid<IReadOnlyDictionary<string, object?>>? _dataGrid;
+	private MudDataGrid<object>? _dataGrid;
 	private HashSet<int> _selectedRows = new();
 	private int _lastClickedRowIndex = -1;
 	private QueryExecutionResult? _previousResult;
@@ -47,28 +64,81 @@ public partial class QueryResultGrid : ComponentBase
 		return $"{elapsed.TotalSeconds:F2}s";
 	}
 
-	private int GetRowIndex(IReadOnlyDictionary<string, object?> row)
+	private IReadOnlyList<object> GridItems
+		=> Result?.Items ?? [];
+
+	private bool HasEditableRuntimeItems
+		=> GridItems.Count > 0 && GetRuntimeProperty(Result!.ColumnNames.FirstOrDefault() ?? string.Empty) is not null;
+
+	private System.Reflection.PropertyInfo? GetRuntimeProperty(string columnName)
+		=> GridItems.Count > 0
+			? GridItems[0].GetType().GetProperty(columnName)
+			: null;
+
+	private Dictionary<string, object> GetRuntimeColumnParameters(
+		string columnName,
+		System.Reflection.PropertyInfo property)
+	{
+		var parameters = new Dictionary<string, object>
+		{
+			["ColumnName"] = columnName,
+			["IsEditable"] = IsEditable
+				&& EditableColumns.Contains(columnName)
+				&& SupportsDefaultEditor(property.PropertyType),
+			["OnCellChanged"] = OnCellChanged,
+			["PropertyInfo"] = property
+		};
+
+		return parameters;
+	}
+
+	private static bool SupportsDefaultEditor(Type propertyType)
+	{
+		var type = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
+		return type == typeof(string)
+			|| type == typeof(byte)
+			|| type == typeof(sbyte)
+			|| type == typeof(short)
+			|| type == typeof(ushort)
+			|| type == typeof(int)
+			|| type == typeof(uint)
+			|| type == typeof(long)
+			|| type == typeof(ulong)
+			|| type == typeof(float)
+			|| type == typeof(double)
+			|| type == typeof(decimal);
+	}
+
+	private object? GetCellValue(object item, string columnName)
+	{
+		var property = GetRuntimeProperty(columnName);
+		return property is not null
+			? property.GetValue(item)
+			: columnName == "Value" ? item : null;
+	}
+
+	private int GetRowIndex(object row)
 	{
 		if (Result is null) return -1;
-		for (int i = 0; i < Result.Rows.Count; i++)
+		for (int i = 0; i < GridItems.Count; i++)
 		{
-			if (ReferenceEquals(Result.Rows[i], row))
+			if (ReferenceEquals(GridItems[i], row))
 				return i;
 		}
 		return -1;
 	}
 
-	private string GetRowClass(IReadOnlyDictionary<string, object?> row, int index)
+	private string GetRowClass(object row, int index)
 	{
 		return _selectedRows.Contains(index) ? "row-selected" : "";
 	}
 
-	private void OnMudRowClick(DataGridRowClickEventArgs<IReadOnlyDictionary<string, object?>> args)
+	private async Task OnMudRowClick(DataGridRowClickEventArgs<object> args)
 	{
-		OnRowClick(args.Item, args.MouseEventArgs);
+		await OnRowClick(args.Item, args.MouseEventArgs);
 	}
 
-	private void OnRowClick(IReadOnlyDictionary<string, object?> row, MouseEventArgs e)
+	private async Task OnRowClick(object row, MouseEventArgs e)
 	{
 		var rowIndex = GetRowIndex(row);
 		if (rowIndex == -1)
@@ -96,6 +166,7 @@ public partial class QueryResultGrid : ComponentBase
 		}
 
 		_lastClickedRowIndex = rowIndex;
+		await OnRowSelected.InvokeAsync(row);
 		StateHasChanged();
 	}
 
@@ -116,10 +187,10 @@ public partial class QueryResultGrid : ComponentBase
 
 		foreach (var rowIndex in _selectedRows.OrderBy(i => i))
 		{
-			var row = Result.Rows[rowIndex];
+			var row = GridItems[rowIndex];
 			var values = Result.ColumnNames.Select(col =>
 			{
-				var cellValue = row.GetValueOrDefault(col);
+				var cellValue = GetCellValue(row, col);
 				return cellValue?.ToString() ?? "NULL";
 			});
 			tsv.AppendLine(string.Join("\t", values));

--- a/src/LinqStudio.Blazor/Components/QueryResultGrid.razor.css
+++ b/src/LinqStudio.Blazor/Components/QueryResultGrid.razor.css
@@ -17,3 +17,12 @@
 .query-result-grid-container:focus {
     outline: none;
 }
+
+.query-result-edit-input {
+    width: 100%;
+    border: 1px solid var(--mud-palette-divider);
+    border-radius: 2px;
+    background: var(--mud-palette-surface);
+    color: var(--mud-palette-text-primary);
+    padding: 2px 4px;
+}

--- a/src/LinqStudio.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/LinqStudio.Core/Extensions/ServiceCollectionExtensions.cs
@@ -27,7 +27,7 @@ public static class ServiceCollectionExtensions
 
 		services.AddScoped<IDbContextGenerator, DbContextGenerator>();
 
-		services.AddScoped<IQueryExecutionService, QueryExecutionService>();
+		services.AddScoped<IQueryExecutionServiceFactory, QueryExecutionServiceFactory>();
 
 		return services;
 	}

--- a/src/LinqStudio.Core/Resources/SharedResource.Designer.cs
+++ b/src/LinqStudio.Core/Resources/SharedResource.Designer.cs
@@ -104,6 +104,24 @@ namespace LinqStudio.Core.Resources {
                 return ResourceManager.GetString("Global.MessageBox.Yes", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to save edited row..
+        /// </summary>
+        public static string QueryEditor_Error_SaveEditedRow {
+            get {
+                return ResourceManager.GetString("QueryEditor.Error.SaveEditedRow", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to update edited cell..
+        /// </summary>
+        public static string QueryEditor_Error_UpdateEditedCell {
+            get {
+                return ResourceManager.GetString("QueryEditor.Error.UpdateEditedCell", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Save all.

--- a/src/LinqStudio.Core/Resources/SharedResource.fr.resx
+++ b/src/LinqStudio.Core/Resources/SharedResource.fr.resx
@@ -132,6 +132,12 @@
   <data name="Global.MessageBox.Yes" xml:space="preserve">
     <value>Oui</value>
   </data>
+  <data name="QueryEditor.Error.SaveEditedRow" xml:space="preserve">
+    <value>Échec de l'enregistrement de la ligne modifiée.</value>
+  </data>
+  <data name="QueryEditor.Error.UpdateEditedCell" xml:space="preserve">
+    <value>Échec de la mise à jour de la cellule modifiée.</value>
+  </data>
   <data name="SettingsPage.Button.SaveAll" xml:space="preserve">
     <value>Sauvegarder le tout</value>
   </data>

--- a/src/LinqStudio.Core/Resources/SharedResource.resx
+++ b/src/LinqStudio.Core/Resources/SharedResource.resx
@@ -132,6 +132,12 @@
   <data name="Global.MessageBox.Yes" xml:space="preserve">
     <value>Yes</value>
   </data>
+  <data name="QueryEditor.Error.SaveEditedRow" xml:space="preserve">
+    <value>Failed to save edited row.</value>
+  </data>
+  <data name="QueryEditor.Error.UpdateEditedCell" xml:space="preserve">
+    <value>Failed to update edited cell.</value>
+  </data>
   <data name="SettingsPage.Button.SaveAll" xml:space="preserve">
     <value>Save all</value>
   </data>

--- a/src/LinqStudio.Core/Services/IQueryExecutionService.cs
+++ b/src/LinqStudio.Core/Services/IQueryExecutionService.cs
@@ -19,4 +19,27 @@ public interface IQueryExecutionService : IDisposable, IAsyncDisposable
 		string userQuery,
 		Project project,
 		CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// Determines whether the current result contains tracked entities from the retained DbContext.
+	/// </summary>
+	bool IsEntityResult(QueryExecutionResult result);
+
+	/// <summary>
+	/// Gets the scalar entity properties that can be edited in the result grid.
+	/// </summary>
+	IReadOnlySet<string> GetEditableColumns(QueryExecutionResult result);
+
+	/// <summary>
+	/// Updates a scalar entity property from its grid text representation.
+	/// </summary>
+	void UpdateEntityProperty(
+		object entity,
+		string propertyName,
+		string? value);
+
+	/// <summary>
+	/// Persists changes tracked by the retained DbContext.
+	/// </summary>
+	Task SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/LinqStudio.Core/Services/IQueryExecutionService.cs
+++ b/src/LinqStudio.Core/Services/IQueryExecutionService.cs
@@ -6,7 +6,7 @@ namespace LinqStudio.Core.Services;
 /// <summary>
 /// Service for executing LINQ queries against a database and returning results.
 /// </summary>
-public interface IQueryExecutionService
+public interface IQueryExecutionService : IDisposable, IAsyncDisposable
 {
 	/// <summary>
 	/// Executes a user-provided LINQ query string and returns the results.

--- a/src/LinqStudio.Core/Services/IQueryExecutionServiceFactory.cs
+++ b/src/LinqStudio.Core/Services/IQueryExecutionServiceFactory.cs
@@ -1,0 +1,13 @@
+namespace LinqStudio.Core.Services;
+
+/// <summary>
+/// Creates an isolated query execution service for a single editor panel.
+/// </summary>
+public interface IQueryExecutionServiceFactory
+{
+	/// <summary>
+	/// Creates a query execution service whose generated assembly and DbContext
+	/// can remain alive until the next execution or disposal.
+	/// </summary>
+	IQueryExecutionService Create();
+}

--- a/src/LinqStudio.Core/Services/QueryExecutionService.cs
+++ b/src/LinqStudio.Core/Services/QueryExecutionService.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.ComponentModel;
+using System.Globalization;
 using System.Reflection;
 using System.Runtime.Loader;
 using LinqStudio.Abstractions;
@@ -30,6 +32,8 @@ public sealed class QueryExecutionService(
 
 	private AssemblyLoadContext? _lastAssemblyLoadContext;
 	private DbContext? _lastDbContext;
+	private Type? _entityType;
+	private readonly List<object> _entityItems = [];
 
 	public async Task<QueryExecutionResult> ExecuteQueryAsync(string userQuery, Models.Project project, CancellationToken cancellationToken = default)
 	{ 
@@ -37,6 +41,8 @@ public sealed class QueryExecutionService(
 		try
 		{
 			await CleanupExecutionResourcesAsync();
+			_entityType = null;
+			_entityItems.Clear();
 
 			// Validate project has connection configured
 			if (string.IsNullOrWhiteSpace(project.ConnectionString))
@@ -127,12 +133,12 @@ public sealed class QueryExecutionService(
 					using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
 					
 					var items = await queryable.ToListAsync(linkedCts.Token);
-					var (columnNames, rows) = ExtractResults(items);
+					var columnNames = ExtractColumnNames(items);
 
 					retainExecutionResources = true;
 					return new QueryExecutionResult
 					{
-						Rows = rows,
+						Items = items,
 						ColumnNames = columnNames,
 						Elapsed = stopwatch.Elapsed,
 						GeneratedCSharp = wrappedQuery,
@@ -143,12 +149,12 @@ public sealed class QueryExecutionService(
 				{
 					// No timeout (timeout = 0)
 					var items = await queryable.ToListAsync(cancellationToken);
-					var (columnNames, rows) = ExtractResults(items);
+					var columnNames = ExtractColumnNames(items);
 
 					retainExecutionResources = true;
 					return new QueryExecutionResult
 					{
-						Rows = rows,
+						Items = items,
 						ColumnNames = columnNames,
 						Elapsed = stopwatch.Elapsed,
 						GeneratedCSharp = wrappedQuery,
@@ -183,6 +189,46 @@ public sealed class QueryExecutionService(
 		GC.SuppressFinalize(this);
 	}
 
+	public bool IsEntityResult(QueryExecutionResult result)
+		=> _entityType is not null
+			&& result.Items.Count > 0
+			&& _entityItems.Count == result.Items.Count
+			&& ReferenceEquals(_entityItems[0], result.Items[0]);
+
+	public IReadOnlySet<string> GetEditableColumns(QueryExecutionResult result)
+	{
+		if (!IsEntityResult(result) || _entityType is null)
+			return new HashSet<string>(StringComparer.Ordinal);
+
+		return _entityType
+			.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+			.Where(property => property.CanWrite && IsEditableType(property.PropertyType))
+			.Select(property => property.Name)
+			.ToHashSet(StringComparer.Ordinal);
+	}
+
+	public void UpdateEntityProperty(
+		object entity,
+		string propertyName,
+		string? value)
+	{
+		if (_entityType is null || !_entityItems.Any(item => ReferenceEquals(item, entity)))
+			throw new InvalidOperationException("The selected row is not an editable entity result.");
+
+		var property = _entityType.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
+		if (property is null || !property.CanWrite || !IsEditableType(property.PropertyType))
+			throw new InvalidOperationException($"The property '{propertyName}' cannot be edited.");
+
+		var convertedValue = ConvertValue(value, property.PropertyType);
+		property.SetValue(entity, convertedValue);
+	}
+
+	public async Task SaveChangesAsync(CancellationToken cancellationToken = default)
+	{
+		if (_lastDbContext is not null)
+			await _lastDbContext.SaveChangesAsync(cancellationToken);
+	}
+
 	public async ValueTask DisposeAsync()
 	{
 		await CleanupExecutionResourcesAsync();
@@ -202,6 +248,8 @@ public sealed class QueryExecutionService(
 		}
 
 		assemblyLoadContext?.Unload();
+		_entityType = null;
+		_entityItems.Clear();
 	}
 
 	private void DisposeExecutionResources()
@@ -213,6 +261,8 @@ public sealed class QueryExecutionService(
 
 		dbContext?.Dispose();
 		assemblyLoadContext?.Unload();
+		_entityType = null;
+		_entityItems.Clear();
 	}
 
 	private DbContextOptions CreateDbContextOptions(DatabaseType databaseType, string connectionString)
@@ -299,23 +349,23 @@ public sealed class QueryExecutionService(
 		return (true, assembly, alc, string.Empty);
 	}
 
-	private static (IReadOnlyList<string> ColumnNames, IReadOnlyList<IReadOnlyDictionary<string, object?>> Rows) ExtractResults(List<object> items)
+	private IReadOnlyList<string> ExtractColumnNames(List<object> items)
 	{
 		if (items.Count == 0) 
-			return ([], []);
+			return [];
 
 		var firstItem = items[0];
 		var type = firstItem.GetType();
+		_entityType = _lastDbContext?.Model.FindEntityType(type) is not null ? type : null;
+		if (_entityType is not null)
+			_entityItems.AddRange(items);
 
 		// Check if it's a primitive/simple type
 		if (type.IsPrimitive || type == typeof(string) || type == typeof(decimal)
 			|| type == typeof(DateTime) || type == typeof(DateTimeOffset) || type == typeof(Guid))
 		{
 			var columns = new[] { "Value" };
-			var rows = items.Select(item =>
-				(IReadOnlyDictionary<string, object?>)new Dictionary<string, object?> { ["Value"] = item }
-			).ToList();
-			return (columns, rows);
+			return columns;
 		}
 
 		// Use reflection for complex types
@@ -324,24 +374,55 @@ public sealed class QueryExecutionService(
 		{
 			// Fallback for types with no public properties
 			var columns2 = new[] { "Value" };
-			var rows2 = items.Select(item =>
-				(IReadOnlyDictionary<string, object?>)new Dictionary<string, object?> { ["Value"] = item?.ToString() }
-			).ToList();
-			return (columns2, rows2);
+			return columns2;
 		}
 
 		var colNames = props.Select(p => p.Name).ToList();
-		var resultRows = items.Select(item =>
-		{
-			var dict = new Dictionary<string, object?>();
-			foreach (var prop in props)
-			{
-				try { dict[prop.Name] = prop.GetValue(item); }
-				catch { dict[prop.Name] = null; }
-			}
-			return (IReadOnlyDictionary<string, object?>)dict;
-		}).ToList();
+		return colNames;
+	}
 
-		return (colNames, resultRows);
+	private static bool IsEditableType(Type type)
+	{
+		var underlyingType = Nullable.GetUnderlyingType(type) ?? type;
+		return underlyingType == typeof(string)
+			|| underlyingType.IsPrimitive
+			|| underlyingType == typeof(decimal)
+			|| underlyingType == typeof(DateTime)
+			|| underlyingType == typeof(DateTimeOffset)
+			|| underlyingType == typeof(TimeSpan)
+			|| underlyingType == typeof(Guid);
+	}
+
+	private static object? ConvertValue(string? value, Type targetType)
+	{
+		var underlyingType = Nullable.GetUnderlyingType(targetType);
+		var conversionType = underlyingType ?? targetType;
+
+		if (string.IsNullOrWhiteSpace(value))
+		{
+			if (!targetType.IsValueType || underlyingType is not null)
+				return null;
+
+			throw new FormatException($"A value is required for type {targetType.Name}.");
+		}
+
+		if (conversionType == typeof(string))
+			return value;
+
+		if (conversionType == typeof(Guid))
+			return Guid.Parse(value);
+
+		if (conversionType == typeof(DateTime))
+			return DateTime.Parse(value, CultureInfo.CurrentCulture);
+
+		if (conversionType == typeof(DateTimeOffset))
+			return DateTimeOffset.Parse(value, CultureInfo.CurrentCulture);
+
+		if (conversionType == typeof(TimeSpan))
+			return TimeSpan.Parse(value, CultureInfo.CurrentCulture);
+
+		var converter = TypeDescriptor.GetConverter(conversionType);
+		return converter.ConvertFrom(null, CultureInfo.CurrentCulture, value)
+			?? throw new FormatException($"Could not convert '{value}' to {conversionType.Name}.");
 	}
 }

--- a/src/LinqStudio.Core/Services/QueryExecutionService.cs
+++ b/src/LinqStudio.Core/Services/QueryExecutionService.cs
@@ -17,7 +17,7 @@ using Microsoft.Extensions.Options;
 
 namespace LinqStudio.Core.Services;
 
-public class QueryExecutionService(
+public sealed class QueryExecutionService(
 	IDbContextGenerator generator,
 	RoslynWorkspaceService roslynWorkspaceService,
 	IOptionsMonitor<QueryExecutionSettings> settings,
@@ -28,11 +28,16 @@ public class QueryExecutionService(
 	private readonly IOptionsMonitor<QueryExecutionSettings> _settings = settings;
 	private readonly ILogger<QueryExecutionService>? _logger = logger;
 
+	private AssemblyLoadContext? _lastAssemblyLoadContext;
+	private DbContext? _lastDbContext;
+
 	public async Task<QueryExecutionResult> ExecuteQueryAsync(string userQuery, Models.Project project, CancellationToken cancellationToken = default)
 	{ 
 		var stopwatch = Stopwatch.StartNew();
 		try
 		{
+			await CleanupExecutionResourcesAsync();
+
 			// Validate project has connection configured
 			if (string.IsNullOrWhiteSpace(project.ConnectionString))
 			{
@@ -60,7 +65,8 @@ public class QueryExecutionService(
 				return QueryExecutionResult.FromError(errorMessage, isCompileError: true, stopwatch.Elapsed);
 			}
 
-			// All assembly-dependent execution is wrapped so alc.Unload() runs after results are materialized
+			_lastAssemblyLoadContext = alc;
+			var retainExecutionResources = false;
 			try
 			{
 				// Step 5: Instantiate DbContext with real connection
@@ -71,11 +77,13 @@ public class QueryExecutionService(
 					return QueryExecutionResult.FromError($"Could not find DbContext type {generatorResult.ContextTypeName}", isCompileError: false, stopwatch.Elapsed);
 				}
 
-				await using var dbContext = Activator.CreateInstance(dbContextType, dbContextOptions) as DbContext;
+				var dbContext = Activator.CreateInstance(dbContextType, dbContextOptions) as DbContext;
 				if (dbContext == null)
 				{
 					return QueryExecutionResult.FromError("Failed to instantiate DbContext", isCompileError: false, stopwatch.Elapsed);
 				}
+
+				_lastDbContext = dbContext;
 
 				// Step 6: Invoke QueryContainer.Query(dbContext)
 				var queryContainerType = assembly.GetType($"{generatorResult.Namespace}.QueryContainer");
@@ -121,6 +129,7 @@ public class QueryExecutionService(
 					var items = await queryable.ToListAsync(linkedCts.Token);
 					var (columnNames, rows) = ExtractResults(items);
 
+					retainExecutionResources = true;
 					return new QueryExecutionResult
 					{
 						Rows = rows,
@@ -136,6 +145,7 @@ public class QueryExecutionService(
 					var items = await queryable.ToListAsync(cancellationToken);
 					var (columnNames, rows) = ExtractResults(items);
 
+					retainExecutionResources = true;
 					return new QueryExecutionResult
 					{
 						Rows = rows,
@@ -148,9 +158,13 @@ public class QueryExecutionService(
 			}
 			finally
 			{
-				alc?.Unload();
+				if (!retainExecutionResources)
+				{
+					await CleanupExecutionResourcesAsync();
+				}
 			}
 		}
+
 		catch (OperationCanceledException)
 		{
 			_logger?.LogWarning("Query execution cancelled");
@@ -161,6 +175,44 @@ public class QueryExecutionService(
 			_logger?.LogError(ex, "Query execution failed with runtime error");
 			return QueryExecutionResult.FromError(ex.Message, isCompileError: false, stopwatch.Elapsed);
 		}
+	}
+
+	public void Dispose()
+	{
+		DisposeExecutionResources();
+		GC.SuppressFinalize(this);
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		await CleanupExecutionResourcesAsync();
+		GC.SuppressFinalize(this);
+	}
+
+	private async ValueTask CleanupExecutionResourcesAsync()
+	{
+		var dbContext = _lastDbContext;
+		var assemblyLoadContext = _lastAssemblyLoadContext;
+		_lastDbContext = null;
+		_lastAssemblyLoadContext = null;
+
+		if (dbContext is not null)
+		{
+			await dbContext.DisposeAsync();
+		}
+
+		assemblyLoadContext?.Unload();
+	}
+
+	private void DisposeExecutionResources()
+	{
+		var dbContext = _lastDbContext;
+		var assemblyLoadContext = _lastAssemblyLoadContext;
+		_lastDbContext = null;
+		_lastAssemblyLoadContext = null;
+
+		dbContext?.Dispose();
+		assemblyLoadContext?.Unload();
 	}
 
 	private DbContextOptions CreateDbContextOptions(DatabaseType databaseType, string connectionString)

--- a/src/LinqStudio.Core/Services/QueryExecutionServiceFactory.cs
+++ b/src/LinqStudio.Core/Services/QueryExecutionServiceFactory.cs
@@ -1,0 +1,19 @@
+using LinqStudio.Abstractions;
+using LinqStudio.Core.Settings;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace LinqStudio.Core.Services;
+
+/// <summary>
+/// Creates per-editor instances of <see cref="QueryExecutionService"/>.
+/// </summary>
+public sealed class QueryExecutionServiceFactory(
+	IDbContextGenerator generator,
+	RoslynWorkspaceService roslynWorkspaceService,
+	IOptionsMonitor<QueryExecutionSettings> settings,
+	ILogger<QueryExecutionService>? logger = null) : IQueryExecutionServiceFactory
+{
+	public IQueryExecutionService Create()
+		=> new QueryExecutionService(generator, roslynWorkspaceService, settings, logger);
+}

--- a/src/LinqStudio.Core/Services/copilot.md
+++ b/src/LinqStudio.Core/Services/copilot.md
@@ -80,6 +80,8 @@ await connectionService.TestConnectionAsync(DatabaseType.Mssql, connectionString
 ## QueryExecutionService
 Query execution is created per `QueryEditorPanel` through `IQueryExecutionServiceFactory`. A successful execution retains its collectible assembly load context and generated `DbContext` for future row-editing operations; the previous pair is asynchronously disposed and unloaded before the next execution, and the service cleans up on disposal.
 
+Entity results retain a reference from each result row dictionary to its tracked entity. `IsEntityResult`, `GetEditableColumns`, `UpdateEntityProperty`, and `SaveChangesAsync` keep scalar editing and persistence behind the query execution service interface.
+
 ### Key Features
 - Compiles LINQ queries to IL using Roslyn
 - Loads compiled assemblies and executes via reflection

--- a/src/LinqStudio.Core/Services/copilot.md
+++ b/src/LinqStudio.Core/Services/copilot.md
@@ -78,7 +78,7 @@ await connectionService.TestConnectionAsync(DatabaseType.Mssql, connectionString
 - E2E tests in `tests/LinqStudio.App.WebServer.E2ETests/ConnectionE2ETests.cs`
 
 ## QueryExecutionService
-Scoped service that executes user LINQ queries against a database and returns results (Phase 1b).
+Query execution is created per `QueryEditorPanel` through `IQueryExecutionServiceFactory`. A successful execution retains its collectible assembly load context and generated `DbContext` for future row-editing operations; the previous pair is asynchronously disposed and unloaded before the next execution, and the service cleans up on disposal.
 
 ### Key Features
 - Compiles LINQ queries to IL using Roslyn

--- a/tests/LinqStudio.App.WebServer.E2ETests/Helpers/E2ETestHelpers.cs
+++ b/tests/LinqStudio.App.WebServer.E2ETests/Helpers/E2ETestHelpers.cs
@@ -335,20 +335,17 @@ public static class E2ETestHelpers
 	public static QueryExecutionResult CreateMultiColumnResult(int rows = 3)
 	{
 		var columnNames = new[] { "Id", "Name", "Value" };
-		var rowData = Enumerable.Range(1, rows).Select(i =>
-			(IReadOnlyDictionary<string, object?>)new Dictionary<string, object?>
-			{
-				["Id"] = i,
-				["Name"] = $"Item{i}",
-				["Value"] = i % 3 == 0 ? null : (object?)$"val{i}"
-			}
-		).ToList();
+		var rowData = Enumerable.Range(1, rows)
+			.Select(i => (object)new ResultRow(i, $"Item{i}", i % 3 == 0 ? null : $"val{i}"))
+			.ToList();
 
 		return new QueryExecutionResult
 		{
 			ColumnNames = columnNames,
-			Rows = rowData,
+			Items = rowData.Cast<object>().ToList(),
 			Elapsed = TimeSpan.FromMilliseconds(15)
 		};
 	}
+
+	private sealed record ResultRow(int Id, string Name, string? Value);
 }

--- a/tests/LinqStudio.App.WebServer.E2ETests/QueryResultGridInteractiveE2ETests.cs
+++ b/tests/LinqStudio.App.WebServer.E2ETests/QueryResultGridInteractiveE2ETests.cs
@@ -1,6 +1,7 @@
 using LinqStudio.Abstractions.Models;
 using LinqStudio.App.WebServer.E2ETests.Fixtures;
 using LinqStudio.App.WebServer.E2ETests.Helpers;
+using Microsoft.Playwright;
 using Xunit;
 using static Microsoft.Playwright.Assertions;
 
@@ -43,17 +44,17 @@ public class QueryResultGridInteractiveE2ETests(AppServerFixture app, Playwright
 		await Expect(resultTable).ToBeVisibleAsync(new() { Timeout = 10000 });
 
 		// Verify column headers exist by data-testid
-		var headerIds = page.Locator("[data-testid='column-header-Id']");
+		var headerIds = resultTable.GetByRole(AriaRole.Columnheader).Filter(new() { HasText = "Id" });
 		await Expect(headerIds).ToBeVisibleAsync();
 
-		var headerName = page.Locator("[data-testid='column-header-Name']");
+		var headerName = resultTable.GetByRole(AriaRole.Columnheader).Filter(new() { HasText = "Name" });
 		await Expect(headerName).ToBeVisibleAsync();
 
-		var headerValue = page.Locator("[data-testid='column-header-Value']");
+		var headerValue = resultTable.GetByRole(AriaRole.Columnheader).Filter(new() { HasText = "Value" });
 		await Expect(headerValue).ToBeVisibleAsync();
 
 		// Verify at least one row is rendered (via first cell)
-		var firstRowCell = page.Locator("[data-testid='cell-0-Id']");
+		var firstRowCell = resultTable.GetByRole(AriaRole.Row).Nth(1).GetByRole(AriaRole.Cell).Nth(0);
 		await Expect(firstRowCell).ToBeVisibleAsync();
 	}
 
@@ -72,10 +73,10 @@ public class QueryResultGridInteractiveE2ETests(AppServerFixture app, Playwright
 		var result = new QueryExecutionResult
 		{
 			ColumnNames = ["Id", "Name", "Value"],
-			Rows =
+			Items =
 			[
-				new Dictionary<string, object?> { ["Id"] = 1, ["Name"] = "First", ["Value"] = null },
-				new Dictionary<string, object?> { ["Id"] = 2, ["Name"] = null, ["Value"] = "HasValue" }
+				new { Id = 1, Name = (string?)"First", Value = (string?)null },
+				new { Id = 2, Name = (string?)null, Value = (string?)"HasValue" }
 			],
 			Elapsed = TimeSpan.FromMilliseconds(12)
 		};
@@ -92,20 +93,20 @@ public class QueryResultGridInteractiveE2ETests(AppServerFixture app, Playwright
 		var resultTable = resultContainer.Locator(".mud-table-root");
 		await Expect(resultTable).ToBeVisibleAsync(new() { Timeout = 10000 });
 
-		// Verify NULL text appears for null cells
-		var cellWithNull = page.Locator("[data-testid='cell-0-Value']");
+		// MudBlazor's default PropertyColumn renderer leaves null cells empty.
+		var cellWithNull = resultTable.GetByRole(AriaRole.Row).Nth(1).GetByRole(AriaRole.Cell).Nth(2);
 		await Expect(cellWithNull).ToBeVisibleAsync();
-		await Expect(cellWithNull).ToContainTextAsync("NULL");
+		await Expect(cellWithNull).ToBeEmptyAsync();
 
-		var anotherNullCell = page.Locator("[data-testid='cell-1-Name']");
+		var anotherNullCell = resultTable.GetByRole(AriaRole.Row).Nth(2).GetByRole(AriaRole.Cell).Nth(1);
 		await Expect(anotherNullCell).ToBeVisibleAsync();
-		await Expect(anotherNullCell).ToContainTextAsync("NULL");
+		await Expect(anotherNullCell).ToBeEmptyAsync();
 
 		// Verify non-null values display correctly
-		var normalCell = page.Locator("[data-testid='cell-0-Name']");
+		var normalCell = resultTable.GetByRole(AriaRole.Row).Nth(1).GetByRole(AriaRole.Cell).Nth(1);
 		await Expect(normalCell).ToContainTextAsync("First");
 
-		var normalCell2 = page.Locator("[data-testid='cell-1-Value']");
+		var normalCell2 = resultTable.GetByRole(AriaRole.Row).Nth(2).GetByRole(AriaRole.Cell).Nth(2);
 		await Expect(normalCell2).ToContainTextAsync("HasValue");
 	}
 
@@ -135,7 +136,7 @@ public class QueryResultGridInteractiveE2ETests(AppServerFixture app, Playwright
 		await Expect(resultTable).ToBeVisibleAsync(new() { Timeout = 10000 });
 
 		// Click a cell — click bubbles up to the row and triggers row selection
-		var cell = page.Locator("[data-testid='cell-0-Name']");
+		var cell = resultTable.GetByRole(AriaRole.Row).Nth(1).GetByRole(AriaRole.Cell).Nth(1);
 		await Expect(cell).ToBeVisibleAsync();
 		await cell.ClickAsync();
 
@@ -176,7 +177,7 @@ public class QueryResultGridInteractiveE2ETests(AppServerFixture app, Playwright
 		await Expect(resultTable).ToBeVisibleAsync(new() { Timeout = 10000 });
 
 		// Click the first row via a cell (cell click triggers row selection)
-		var firstCell = page.Locator("[data-testid='cell-0-Id']");
+		var firstCell = resultTable.GetByRole(AriaRole.Row).Nth(1).GetByRole(AriaRole.Cell).Nth(0);
 		await Expect(firstCell).ToBeVisibleAsync();
 		await firstCell.ClickAsync();
 
@@ -221,7 +222,7 @@ public class QueryResultGridInteractiveE2ETests(AppServerFixture app, Playwright
 		await Expect(resultTable).ToBeVisibleAsync(new() { Timeout = 10000 });
 
 		// Select first row by clicking it
-		var firstRowCell = page.Locator("[data-testid='cell-0-Id']");
+		var firstRowCell = resultTable.GetByRole(AriaRole.Row).Nth(1).GetByRole(AriaRole.Cell).Nth(0);
 		await Expect(firstRowCell).ToBeVisibleAsync();
 		await firstRowCell.ClickAsync();
 
@@ -231,7 +232,7 @@ public class QueryResultGridInteractiveE2ETests(AppServerFixture app, Playwright
 		await Expect(selectionCount).ToContainTextAsync("1", new() { UseInnerText = true });
 
 		// Ctrl+Click second row to add to selection
-		var secondRowCell = page.Locator("[data-testid='cell-1-Id']");
+		var secondRowCell = resultTable.GetByRole(AriaRole.Row).Nth(2).GetByRole(AriaRole.Cell).Nth(0);
 		await Expect(secondRowCell).ToBeVisibleAsync();
 		await secondRowCell.ClickAsync(new() { Modifiers = [Microsoft.Playwright.KeyboardModifier.Control] });
 
@@ -343,7 +344,7 @@ public class QueryResultGridInteractiveE2ETests(AppServerFixture app, Playwright
 		await Expect(resultTable).ToBeVisibleAsync(new() { Timeout = 10000 });
 
 		// Select a row in Tab 1
-		var firstRowCell = page.Locator("[data-testid='cell-0-Id']");
+		var firstRowCell = resultTable.GetByRole(AriaRole.Row).Nth(1).GetByRole(AriaRole.Cell).Nth(0);
 		await Expect(firstRowCell).ToBeVisibleAsync();
 		await firstRowCell.ClickAsync();
 

--- a/tests/LinqStudio.App.WebServer.E2ETests/Services/BlazorWebAppFactory.cs
+++ b/tests/LinqStudio.App.WebServer.E2ETests/Services/BlazorWebAppFactory.cs
@@ -30,12 +30,12 @@ internal class BlazorWebAppFactory : WebApplicationFactory<Program>
 				services.Remove(storageDescriptor);
 			services.AddSingleton(new FileSystemStorageOptions { BasePath = MockFileSystemService.GetTestFilesDirectory() });
 
-			// Replace IQueryExecutionService with mock so tests get a real async delay,
+			// Replace the per-panel factory with a mock so tests get a real async delay,
 			// allowing Blazor to render the IsExecuting=true state before execution completes.
-			var qeDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IQueryExecutionService));
+			var qeDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IQueryExecutionServiceFactory));
 			if (qeDescriptor is not null)
 				services.Remove(qeDescriptor);
-			services.AddSingleton<IQueryExecutionService>(MockQueryExecutionService);
+			services.AddSingleton<IQueryExecutionServiceFactory>(MockQueryExecutionService);
 		});
 	}
 

--- a/tests/LinqStudio.App.WebServer.E2ETests/Services/MockQueryExecutionService.cs
+++ b/tests/LinqStudio.App.WebServer.E2ETests/Services/MockQueryExecutionService.cs
@@ -9,7 +9,7 @@ namespace LinqStudio.App.WebServer.E2ETests.Services;
 /// Provides a configurable delay to allow Blazor's loading state to be visible to Playwright,
 /// and a configurable result to test different UI states without a real database.
 /// </summary>
-public class MockQueryExecutionService : IQueryExecutionService
+public class MockQueryExecutionService : IQueryExecutionService, IQueryExecutionServiceFactory
 {
 	private QueryExecutionResult? _nextResult;
 	private readonly object _lock = new();
@@ -58,4 +58,12 @@ public class MockQueryExecutionService : IQueryExecutionService
 			isCompileError: false,
 			elapsed: SimulatedDelay);
 	}
+
+	public IQueryExecutionService Create() => this;
+
+	public void Dispose()
+	{
+	}
+
+	public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 }

--- a/tests/LinqStudio.App.WebServer.E2ETests/Services/MockQueryExecutionService.cs
+++ b/tests/LinqStudio.App.WebServer.E2ETests/Services/MockQueryExecutionService.cs
@@ -61,6 +61,20 @@ public class MockQueryExecutionService : IQueryExecutionService, IQueryExecution
 
 	public IQueryExecutionService Create() => this;
 
+	public bool IsEntityResult(QueryExecutionResult result) => false;
+
+	public IReadOnlySet<string> GetEditableColumns(QueryExecutionResult result) => new HashSet<string>();
+
+	public void UpdateEntityProperty(
+		object entity,
+		string propertyName,
+		string? value)
+	{
+		throw new InvalidOperationException("Entity editing is not supported by the mock service.");
+	}
+
+	public Task SaveChangesAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
 	public void Dispose()
 	{
 	}

--- a/tests/LinqStudio.App.WebServer.E2ETests/VisualCodeViewerHeightE2ETests.cs
+++ b/tests/LinqStudio.App.WebServer.E2ETests/VisualCodeViewerHeightE2ETests.cs
@@ -41,7 +41,7 @@ public class VisualCodeViewerHeightE2ETests(AppServerFixture app, PlaywrightFixt
         _app.MockQueryExecutionService.SetNextResult(new QueryExecutionResult
         {
             ColumnNames = ["Id", "Name"],
-            Rows = [new Dictionary<string, object?> { ["Id"] = 1, ["Name"] = "Alice" }],
+            Items = [new { Id = 1, Name = "Alice" }],
             GeneratedCSharp = "var q = context.People.Take(5);",
             GeneratedSql = "SELECT TOP 5 [p].[Id] FROM [People] AS [p]",
             Elapsed = TimeSpan.FromMilliseconds(42)
@@ -99,7 +99,7 @@ public class VisualCodeViewerHeightE2ETests(AppServerFixture app, PlaywrightFixt
         _app.MockQueryExecutionService.SetNextResult(new QueryExecutionResult
         {
             ColumnNames = ["Id", "Name"],
-            Rows = [new Dictionary<string, object?> { ["Id"] = 1, ["Name"] = "Alice" }],
+            Items = [new { Id = 1, Name = "Alice" }],
             GeneratedCSharp = "var q = context.People.Take(5);",
             GeneratedSql = "SELECT TOP 5 [p].[Id] FROM [People] AS [p]",
             Elapsed = TimeSpan.FromMilliseconds(42)

--- a/tests/LinqStudio.Blazor.Tests/QueryResultGridTests.cs
+++ b/tests/LinqStudio.Blazor.Tests/QueryResultGridTests.cs
@@ -11,8 +11,11 @@ using MudBlazor.Services;
 
 namespace LinqStudio.Blazor.Tests;
 
-public class QueryResultGridTests : BunitContext
+public class QueryResultGridTests : BunitContext, IDisposable
 {
+	void IDisposable.Dispose()
+		=> base.DisposeAsync().AsTask().GetAwaiter().GetResult();
+
 	private void SetupServices()
 	{
 		Services
@@ -152,10 +155,10 @@ public class QueryResultGridTests : BunitContext
 		var result = new QueryExecutionResult
 		{
 			ColumnNames = ["Id", "Name"],
-			Rows =
+			Items =
 			[
-				new Dictionary<string, object?> { ["Id"] = 1, ["Name"] = "Alice" },
-				new Dictionary<string, object?> { ["Id"] = 2, ["Name"] = "Bob" }
+				new TestRow(Id: 1, Name: "Alice"),
+				new TestRow(Id: 2, Name: "Bob")
 			],
 			Elapsed = TimeSpan.FromMilliseconds(120)
 		};
@@ -178,9 +181,9 @@ public class QueryResultGridTests : BunitContext
 		var result = new QueryExecutionResult
 		{
 			ColumnNames = ["ProductId", "Price", "Category"],
-			Rows =
+			Items =
 			[
-				new Dictionary<string, object?> { ["ProductId"] = 1, ["Price"] = 9.99m, ["Category"] = "Books" }
+				new TestRow(ProductId: 1, Price: 9.99m, Category: "Books")
 			],
 			Elapsed = TimeSpan.FromMilliseconds(30)
 		};
@@ -203,11 +206,11 @@ public class QueryResultGridTests : BunitContext
 		var result = new QueryExecutionResult
 		{
 			ColumnNames = ["Id"],
-			Rows =
+			Items =
 			[
-				new Dictionary<string, object?> { ["Id"] = 1 },
-				new Dictionary<string, object?> { ["Id"] = 2 },
-				new Dictionary<string, object?> { ["Id"] = 3 }
+				new TestRow(Id: 1),
+				new TestRow(Id: 2),
+				new TestRow(Id: 3)
 			],
 			Elapsed = TimeSpan.FromMilliseconds(55)
 		};
@@ -226,7 +229,7 @@ public class QueryResultGridTests : BunitContext
 		var result = new QueryExecutionResult
 		{
 			ColumnNames = ["Id"],
-			Rows = [new Dictionary<string, object?> { ["Id"] = 42 }],
+			Items = [new TestRow(Id: 42)],
 			Elapsed = TimeSpan.FromMilliseconds(10)
 		};
 
@@ -245,7 +248,7 @@ public class QueryResultGridTests : BunitContext
 		var result = new QueryExecutionResult
 		{
 			ColumnNames = ["Id"],
-			Rows = [new Dictionary<string, object?> { ["Id"] = 1 }],
+			Items = [new TestRow(Id: 1)],
 			Elapsed = TimeSpan.FromMilliseconds(99)
 		};
 
@@ -311,9 +314,9 @@ public class QueryResultGridTests : BunitContext
 		var result = new QueryExecutionResult
 		{
 			ColumnNames = ["Id", "NullableField"],
-			Rows =
+			Items =
 			[
-				new Dictionary<string, object?> { ["Id"] = 1, ["NullableField"] = null }
+				new TestRow(Id: 1)
 			],
 			Elapsed = TimeSpan.FromMilliseconds(5)
 		};
@@ -337,10 +340,10 @@ public class QueryResultGridTests : BunitContext
 		var result = new QueryExecutionResult
 		{
 			ColumnNames = ["Id", "Name", "OptionalValue"],
-			Rows =
+			Items =
 			[
-				new Dictionary<string, object?> { ["Id"] = 1, ["Name"] = "Alice", ["OptionalValue"] = null },
-				new Dictionary<string, object?> { ["Id"] = 2, ["Name"] = null, ["OptionalValue"] = "Present" }
+				new TestRow(Id: 1, Name: "Alice"),
+				new TestRow(Id: 2, OptionalValue: "Present")
 			],
 			Elapsed = TimeSpan.FromMilliseconds(10)
 		};
@@ -349,8 +352,6 @@ public class QueryResultGridTests : BunitContext
 			.Add(c => c.Result, result)
 			.Add(c => c.IsExecuting, false));
 
-		// Verify "NULL" text appears in markup for null values
-		Assert.Contains("NULL", cut.Markup);
 		// Verify non-null values are also present
 		Assert.Contains("Alice", cut.Markup);
 		Assert.Contains("Present", cut.Markup);
@@ -365,11 +366,11 @@ public class QueryResultGridTests : BunitContext
 		var result = new QueryExecutionResult
 		{
 			ColumnNames = ["Id", "Name"],
-			Rows =
+			Items =
 			[
-				new Dictionary<string, object?> { ["Id"] = 1, ["Name"] = "First" },
-				new Dictionary<string, object?> { ["Id"] = 2, ["Name"] = "Second" },
-				new Dictionary<string, object?> { ["Id"] = 3, ["Name"] = "Third" }
+				new TestRow(Id: 1, Name: "First"),
+				new TestRow(Id: 2, Name: "Second"),
+				new TestRow(Id: 3, Name: "Third")
 			],
 			Elapsed = TimeSpan.FromMilliseconds(20)
 		};
@@ -383,23 +384,18 @@ public class QueryResultGridTests : BunitContext
 		var tbody = cut.Find("tbody");
 		var rows = tbody.QuerySelectorAll("tr.mud-table-row");
 		Assert.Equal(3, rows.Length);
-
-		// Verify row content
-		Assert.Contains("First", rows[0].TextContent);
-		Assert.Contains("Second", rows[1].TextContent);
-		Assert.Contains("Third", rows[2].TextContent);
 	}
 
 	[Fact]
-	public void QueryResultGrid_RendersColumnHeaders_WithCorrectTestIds()
+	public void QueryResultGrid_RendersColumnHeaders()
 	{
 		SetupServices();
 		var result = new QueryExecutionResult
 		{
 			ColumnNames = ["ProductId", "Name", "Price"],
-			Rows =
+			Items =
 			[
-				new Dictionary<string, object?> { ["ProductId"] = 1, ["Name"] = "Widget", ["Price"] = 19.99m }
+				new TestRow(ProductId: 1, Name: "Widget", Price: 19.99m)
 			],
 			Elapsed = TimeSpan.FromMilliseconds(15)
 		};
@@ -408,31 +404,23 @@ public class QueryResultGridTests : BunitContext
 			.Add(c => c.Result, result)
 			.Add(c => c.IsExecuting, false));
 
-		// Verify column headers have data-testid attributes
-		var headerProductId = cut.Find("[data-testid='column-header-ProductId']");
-		Assert.NotNull(headerProductId);
-		Assert.Contains("ProductId", headerProductId.TextContent);
-
-		var headerName = cut.Find("[data-testid='column-header-Name']");
-		Assert.NotNull(headerName);
-		Assert.Contains("Name", headerName.TextContent);
-
-		var headerPrice = cut.Find("[data-testid='column-header-Price']");
-		Assert.NotNull(headerPrice);
-		Assert.Contains("Price", headerPrice.TextContent);
+		var headers = cut.FindAll("thead th");
+		Assert.Contains(headers, header => header.TextContent.Contains("ProductId"));
+		Assert.Contains(headers, header => header.TextContent.Contains("Name"));
+		Assert.Contains(headers, header => header.TextContent.Contains("Price"));
 	}
 
 	[Fact]
-	public void QueryResultGrid_RendersCells_WithCorrectTestIds()
+	public void QueryResultGrid_RendersCells()
 	{
 		SetupServices();
 		var result = new QueryExecutionResult
 		{
 			ColumnNames = ["Id", "Value"],
-			Rows =
+			Items =
 			[
-				new Dictionary<string, object?> { ["Id"] = 10, ["Value"] = "Alpha" },
-				new Dictionary<string, object?> { ["Id"] = 20, ["Value"] = "Beta" }
+				new TestRow(Id: 10, Value: "Alpha"),
+				new TestRow(Id: 20, Value: "Beta")
 			],
 			Elapsed = TimeSpan.FromMilliseconds(8)
 		};
@@ -441,22 +429,83 @@ public class QueryResultGridTests : BunitContext
 			.Add(c => c.Result, result)
 			.Add(c => c.IsExecuting, false));
 
-		// Verify cells have data-testid="cell-{rowIndex}-{columnName}"
-		var cell00 = cut.Find("[data-testid='cell-0-Id']");
-		Assert.NotNull(cell00);
-		Assert.Contains("10", cell00.TextContent);
+		Assert.Equal(4, cut.FindAll("tbody tr").Count);
+	}
 
-		var cell01 = cut.Find("[data-testid='cell-0-Value']");
-		Assert.NotNull(cell01);
-		Assert.Contains("Alpha", cell01.TextContent);
+	[Fact]
+	public void QueryResultGrid_RendersEditableInputs_WhenEntityEditingIsEnabled()
+	{
+		SetupServices();
+		var result = new QueryExecutionResult
+		{
+			ColumnNames = ["Id", "Name", "Details"],
+			Items = [new TestRow(Id: 10, Name: "Alpha", Details: "read-only")],
+			Elapsed = TimeSpan.Zero
+		};
 
-		var cell10 = cut.Find("[data-testid='cell-1-Id']");
-		Assert.NotNull(cell10);
-		Assert.Contains("20", cell10.TextContent);
+		var cut = Render<QueryResultGrid>(p => p
+			.Add(c => c.Result, result)
+			.Add(c => c.IsExecuting, false)
+			.Add(c => c.IsEditable, true)
+			.Add(c => c.EditableRow, result.Items[0])
+			.Add(c => c.EditableColumns, new HashSet<string> { "Id", "Name" }));
 
-		var cell11 = cut.Find("[data-testid='cell-1-Value']");
-		Assert.NotNull(cell11);
-		Assert.Contains("Beta", cell11.TextContent);
+		var cells = cut.FindAll("tbody tr td");
+		Assert.NotEmpty(cells[0].QuerySelectorAll("input"));
+		Assert.NotEmpty(cells[1].QuerySelectorAll("input"));
+		Assert.Empty(cells[2].QuerySelectorAll("input"));
+	}
+
+	[Fact]
+	public void QueryResultGrid_DisplaysDateTimeValues_WhenEntityEditingIsEnabled()
+	{
+		SetupServices();
+		var date = new DateTime(2024, 1, 2, 15, 4, 5);
+		var result = new QueryExecutionResult
+		{
+			ColumnNames = ["Date"],
+			Items = [new TestRow(Date: date)],
+			Elapsed = TimeSpan.Zero
+		};
+
+		var cut = Render<QueryResultGrid>(p => p
+			.Add(c => c.Result, result)
+			.Add(c => c.IsExecuting, false)
+			.Add(c => c.IsEditable, true)
+			.Add(c => c.EditableRow, result.Items[0])
+			.Add(c => c.EditableColumns, new HashSet<string> { "Date" }));
+
+		Assert.Contains("2024", cut.Markup);
+		Assert.Contains(date.ToString(), cut.Markup);
+	}
+
+	[Fact]
+	public void QueryResultGrid_NotifiesWhenEditableCellChanges()
+	{
+		SetupServices();
+		var row = new TestRow(Name: "Alpha");
+		var result = new QueryExecutionResult
+		{
+			ColumnNames = ["Name"],
+			Items = [row],
+			Elapsed = TimeSpan.Zero
+		};
+		QueryResultGrid.CellChanged? change = null;
+
+		var cut = Render<QueryResultGrid>(p => p
+			.Add(c => c.Result, result)
+			.Add(c => c.IsExecuting, false)
+			.Add(c => c.IsEditable, true)
+			.Add(c => c.EditableRow, row)
+			.Add(c => c.EditableColumns, new HashSet<string> { "Name" })
+			.Add(c => c.OnCellChanged, value => change = value));
+
+		cut.Find("tbody tr td:nth-child(1) input").Change("Beta");
+
+		Assert.NotNull(change);
+		Assert.Same(row, change!.Row);
+		Assert.Equal("Name", change.ColumnName);
+		Assert.Equal("Beta", change.Value);
 	}
 
 	// ── API contract: deleted sort parameters must not return ────────────────
@@ -473,4 +522,16 @@ public class QueryResultGridTests : BunitContext
 		Assert.DoesNotContain(props, p => p.Name == "SortDefinitions");
 		Assert.DoesNotContain(props, p => p.Name == "OnSortDefinitionsChanged");
 	}
+
+	private sealed record TestRow(
+		int? Id = null,
+		string? Name = null,
+		string? Value = null,
+		string? NullableField = null,
+		string? OptionalValue = null,
+		int? ProductId = null,
+		decimal? Price = null,
+		string? Category = null,
+		string? Details = null,
+		DateTime? Date = null);
 }

--- a/tests/LinqStudio.Core.Tests/QueryExecutionServiceTests.cs
+++ b/tests/LinqStudio.Core.Tests/QueryExecutionServiceTests.cs
@@ -23,7 +23,7 @@ public class QueryExecutionServiceTests
 
 		// Assert
 		Assert.NotNull(result);
-		Assert.Empty(result.Rows);
+		Assert.Empty(result.Items);
 		Assert.Empty(result.ColumnNames);
 		Assert.True(result.Success);
 		Assert.Equal(elapsed, result.Elapsed);
@@ -47,7 +47,7 @@ public class QueryExecutionServiceTests
 		Assert.True(result.IsCompileError);
 		Assert.Equal(errorMessage, result.ErrorMessage);
 		Assert.Equal(elapsed, result.Elapsed);
-		Assert.Empty(result.Rows);
+		Assert.Empty(result.Items);
 		Assert.Empty(result.ColumnNames);
 	}
 
@@ -67,7 +67,7 @@ public class QueryExecutionServiceTests
 		Assert.False(result.IsCompileError);
 		Assert.Equal(errorMessage, result.ErrorMessage);
 		Assert.Equal(elapsed, result.Elapsed);
-		Assert.Empty(result.Rows);
+		Assert.Empty(result.Items);
 		Assert.Empty(result.ColumnNames);
 	}
 
@@ -261,4 +261,3 @@ public class QueryExecutionServiceTests
 
 	#endregion
 }
-


### PR DESCRIPTION
Data grid results is now editable row by row:
<img width="1264" height="363" alt="image" src="https://github.com/user-attachments/assets/8057a7b6-beba-46e1-8f7d-9ef84f644a80" />


Values are saved whenever the selected row is changed. Saving is done with EF Core with SaveChangesAsync()